### PR TITLE
Remove superfluous works in configurable section

### DIFF
--- a/docs/themes/kube/layouts/index.html
+++ b/docs/themes/kube/layouts/index.html
@@ -19,7 +19,7 @@
           <img alt="configurable" height="48" src="/images/settings.png" width="64">
         </figure>
         <h3>configurable</h3>
-        <p>configured with entirely with C#; you can customize every piece, and change any behavior!</p>
+        <p>configured entirely with C#; you can customize every piece, and change any behavior!</p>
       </div>
       <div class="col col-4 item">
         <figure>


### PR DESCRIPTION
This PR, if merged, removes a superfluous "with" within the configurable section on the home page.

---

The original text:

> configured with entirely with C#; you can customize every piece, and change any behavior!

The new text:

> configured entirely with C#; you can customize every piece, and change any behavior!