### PR TITLE
Fix concurrency errors in workspace window-management

### DIFF
--- a/src/workspacer.ActionMenu/ActionMenuPlugin.cs
+++ b/src/workspacer.ActionMenu/ActionMenuPlugin.cs
@@ -80,13 +80,10 @@ namespace workspacer.ActionMenu
             var workspaces = context.WorkspaceContainer.GetAllWorkspaces();
             foreach (var workspace in workspaces)
             {
-                foreach (var window in workspace.Windows)
+                foreach (var window in workspace.ManagedWindows)
                 {
-                    if (window.CanLayout)
-                    {
-                        var text = $"[{workspace.Name}] {window.Title}";
-                        builder.Add(text, () => context.Workspaces.SwitchToWindow(window));
-                    }
+                    var text = $"[{workspace.Name}] {window.Title}";
+                    builder.Add(text, () => context.Workspaces.SwitchToWindow(window));
                 }
             }
             return builder;

--- a/src/workspacer.Bar/Widgets/TitleWidget.cs
+++ b/src/workspacer.Bar/Widgets/TitleWidget.cs
@@ -39,7 +39,7 @@ namespace workspacer.Bar.Widgets
             var currentWorkspace = Context.WorkspaceContainer.GetWorkspaceForMonitor(Context.Monitor);
             return currentWorkspace.FocusedWindow ??
                    currentWorkspace.LastFocusedWindow ??
-                   currentWorkspace.Windows.FirstOrDefault(w => w.CanLayout);
+                   currentWorkspace.ManagedWindows.FirstOrDefault();
         }
 
         private void RefreshAddRemove(IWindow window, IWorkspace workspace)

--- a/src/workspacer.Bar/Widgets/WorkspaceWidget.cs
+++ b/src/workspacer.Bar/Widgets/WorkspaceWidget.cs
@@ -95,7 +95,7 @@ namespace workspacer.Bar.Widgets
                 return WorkspaceHasFocusColor;
             }
 
-            var hasWindows = workspace.Windows.Any(w => w.CanLayout);
+            var hasWindows = workspace.ManagedWindows.Count != 0;
             return hasWindows ? null : WorkspaceEmptyColor;
         }
 

--- a/src/workspacer.Shared/Workspace/IWorkspace.cs
+++ b/src/workspacer.Shared/Workspace/IWorkspace.cs
@@ -29,6 +29,11 @@ namespace workspacer
         IEnumerable<IWindow> Windows { get; }
 
         /// <summary>
+        /// set of windows that are contained within the workspace and which workspacer can layout.
+        /// </summary>
+        IList<IWindow> ManagedWindows { get; }
+
+        /// <summary>
         /// currently focused window in the workspace, or null if there is no focused window in the workspace
         /// </summary>
         IWindow FocusedWindow { get; }

--- a/src/workspacer.Shared/Workspace/Workspace.cs
+++ b/src/workspacer.Shared/Workspace/Workspace.cs
@@ -11,7 +11,18 @@ namespace workspacer
     {
         private static Logger Logger = Logger.Create();
 
-        public IEnumerable<IWindow> Windows => _windows;
+        public IEnumerable<IWindow> Windows
+        {
+            get
+            {
+                lock (_windows)
+                {
+                    // return copy to prevent race-conditions!
+                    return _windows.ToList();
+                }
+            }
+        }
+
         public IList<IWindow> ManagedWindows
         {
             get

--- a/src/workspacer.Shared/Workspace/Workspace.cs
+++ b/src/workspacer.Shared/Workspace/Workspace.cs
@@ -12,6 +12,7 @@ namespace workspacer
         private static Logger Logger = Logger.Create();
 
         public IEnumerable<IWindow> Windows => _windows;
+        public IList<IWindow> ManagedWindows => _windows.Where(w => w.CanLayout).ToList();
         public IWindow FocusedWindow => _windows.FirstOrDefault(w => w.IsFocused);
         public IWindow LastFocusedWindow => _lastFocused;
         public string Name { get; }
@@ -52,7 +53,7 @@ namespace workspacer
         {
             if (_lastFocused == window)
             {
-                var windows = GetWindowsForLayout();
+                var windows = ManagedWindows;
                 var next = windows.Count > 1 ? windows[(windows.IndexOf(window) + 1) % windows.Count] : null;
                 _lastFocused = next;
             }
@@ -74,7 +75,7 @@ namespace workspacer
 
         public void CloseFocusedWindow()
         {
-            var window = GetWindowsForLayout().FirstOrDefault(w => w.IsFocused);
+            var window = ManagedWindows.FirstOrDefault(w => w.IsFocused);
             window?.Close();
         }
 
@@ -123,7 +124,7 @@ namespace workspacer
 
         public void FocusNextWindow()
         {
-            var windows = GetWindowsForLayout();
+            var windows = ManagedWindows;
             var didFocus = false;
             for (var i = 0; i < windows.Count; i++)
             {
@@ -157,7 +158,7 @@ namespace workspacer
 
         public void FocusPreviousWindow()
         {
-            var windows = GetWindowsForLayout();
+            var windows = ManagedWindows;
             var didFocus = false;
             for (var i = 0; i < windows.Count; i++)
             {
@@ -191,16 +192,13 @@ namespace workspacer
 
         public void FocusPrimaryWindow()
         {
-            var windows = GetWindowsForLayout();
-            if (windows.Count > 0)
-            {
-                windows[0].Focus();
-            }
+            var window = ManagedWindows.FirstOrDefault();
+            window?.Focus();
         }
 
         public void SwapFocusAndPrimaryWindow()
         {
-            var windows = GetWindowsForLayout();
+            var windows = ManagedWindows;
             if (windows.Count > 1)
             {
                 var primary = windows[0];
@@ -215,7 +213,7 @@ namespace workspacer
 
         public void SwapFocusAndNextWindow()
         {
-            var windows = GetWindowsForLayout();
+            var windows = ManagedWindows;
             for (var i = 0; i < windows.Count; i++)
             {
                 var window = windows[i];
@@ -236,7 +234,7 @@ namespace workspacer
 
         public void SwapFocusAndPreviousWindow()
         {
-            var windows = GetWindowsForLayout();
+            var windows = ManagedWindows;
             for (var i = 0; i < windows.Count; i++)
             {
                 var window = windows[i];
@@ -280,7 +278,7 @@ namespace workspacer
 
         public void SwapWindowToPoint(IWindow window, int x, int y)
         {
-            var windows = GetWindowsForLayout();
+            var windows = ManagedWindows;
             if (windows.Contains(window))
             {
                 var index = GetLayoutSlotIndexForPoint(x, y);
@@ -325,7 +323,7 @@ namespace workspacer
 
         private IEnumerable<IWindowLocation> CalcLayout()
         {
-            var windows = GetWindowsForLayout();
+            var windows = ManagedWindows;
             var monitor = _context.WorkspaceContainer.GetCurrentMonitorForWorkspace(this);
             if (monitor != null)
             {
@@ -336,7 +334,7 @@ namespace workspacer
 
         public void DoLayout()
         {
-            var windows = GetWindowsForLayout();
+            var windows = ManagedWindows.ToList();
             if (_context.Enabled)
             {
                 var monitor = _context.WorkspaceContainer.GetCurrentMonitorForWorkspace(this);
@@ -373,11 +371,6 @@ namespace workspacer
             {
                 windows.ForEach(w => w.ShowInCurrentState());
             }
-        }
-
-        private List<IWindow> GetWindowsForLayout()
-        {
-            return this.Windows.Where(w => w.CanLayout).ToList();
         }
 
         public override string ToString()

--- a/src/workspacer.Shared/Workspace/Workspace.cs
+++ b/src/workspacer.Shared/Workspace/Workspace.cs
@@ -22,7 +22,17 @@ namespace workspacer
                 }
             }
         }
-        public IWindow FocusedWindow => _windows.FirstOrDefault(w => w.IsFocused);
+        public IWindow FocusedWindow
+        {
+            get
+            {
+                lock (_windows)
+                {
+                    return _windows.FirstOrDefault(w => w.IsFocused);
+                }
+            }
+        }
+            
         public IWindow LastFocusedWindow => _lastFocused;
         public string Name { get; }
         public string LayoutName => _layoutEngines[_layoutIndex].Name;
@@ -395,12 +405,15 @@ namespace workspacer
 
         private void SwapWindows(IWindow left, IWindow right)
         {
-            Logger.Trace("SwapWindows[{0},{1}]", left, right);
-            var leftIdx = _windows.FindIndex(w => w == left);
-            var rightIdx = _windows.FindIndex(w => w == right);
+            lock (_windows)
+            {
+                Logger.Trace("SwapWindows[{0},{1}]", left, right);
+                var leftIdx = _windows.FindIndex(w => w == left);
+                var rightIdx = _windows.FindIndex(w => w == right);
 
-            _windows[leftIdx] = right;
-            _windows[rightIdx] = left;
+                _windows[leftIdx] = right;
+                _windows[rightIdx] = left;
+            }
 
             DoLayout();
         }

--- a/src/workspacer/ConfigContext.cs
+++ b/src/workspacer/ConfigContext.cs
@@ -206,10 +206,8 @@ namespace workspacer
             var list = new List<IntPtr>();
             foreach (var ws in WorkspaceContainer.GetAllWorkspaces())
             {
-                foreach (var w in ws.Windows.Where(w => w.CanLayout))
-                {
-                    list.Add(w.Handle);
-                }
+                var handles = ws.ManagedWindows.Select(i => i.Handle);
+                list.AddRange(handles);
             }
             return list;
         }

--- a/src/workspacer/Workspace/WorkspaceManager.cs
+++ b/src/workspacer/Workspace/WorkspaceManager.cs
@@ -174,7 +174,7 @@ namespace workspacer
 
             if (window != null && targetWorkspace != null)
             {
-                var windows = FocusedWorkspace.Windows.Where(w => w.CanLayout);
+                var windows = FocusedWorkspace.ManagedWindows;
                 // get next window
                 var nextWindow = windows.SkipWhile(x => x != window).Skip(1).FirstOrDefault();
                 if (nextWindow == null)
@@ -205,7 +205,7 @@ namespace workspacer
 
             if (window != null && targetWorkspace != null)
             {
-                var windows = FocusedWorkspace.Windows.Where(w => w.CanLayout);
+                var windows = FocusedWorkspace.ManagedWindows;
                 // get next window
                 var nextWindow = windows.SkipWhile(x => x != window).Skip(1).FirstOrDefault();
                 if (nextWindow == null)


### PR DESCRIPTION
This PR fixes a concurrency error related to workspace windows-management. See https://github.com/rickbutton/workspacer/issues/76.

While fixing this, I also noticed lots of code-duplication w.r.t. `IWorkspace.Windows`. I created a new property called "Managed Windows" to cut down on the repetition. 

Not sure if it's the best name, but it was the first decent name I could come up with. Maybe you have a better suggestion?