### PR TITLE
ConfigContext: Use explicit types.

### DIFF
--- a/src/workspacer/ConfigContext.cs
+++ b/src/workspacer/ConfigContext.cs
@@ -261,7 +261,7 @@ namespace workspacer
             }
         }
 
-        private object GetState()
+        private WorkspacerState GetState()
         {
             var state = new WorkspacerState()
             {


### PR DESCRIPTION
This one probably makes no difference in the big picture, but I just *hate* seeing method returned untyped data, when there's no reason to do so.

Again: Take it or leave it :smile: 