### PR TITLE
Prevent inlining of Logger.Create()

### DIFF
--- a/src/workspacer.Shared/Logger.cs
+++ b/src/workspacer.Shared/Logger.cs
@@ -135,6 +135,7 @@ namespace workspacer
         /// create an instance of Logger, using the current class as context
         /// </summary>
         /// <returns></returns>
+        [System.Runtime.CompilerServices.MethodImplAttribute(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         public static Logger Create()
         {
             var trace = new StackTrace();


### PR DESCRIPTION
Logger.Create() depends on analyzing the call-stack to determine who it is creating a Logger for.

In the -current- workspacer-codebase this probably works fine.

But in my experience, especially in optimized release-builds, some method-calls tend to get inlined, making stack-frame analyzis unreliable, and worst case a cause of bugs or misleading logs.

We can prevent this from ever happening by instructing the compiler to never inline this method-call.

So let's do just that :)