### PR TITLE
Fix runtime-error when not running as 64-bit process.

### DIFF
--- a/src/workspacer.Native/Native/Win32/Win32.Long.cs
+++ b/src/workspacer.Native/Native/Win32/Win32.Long.cs
@@ -69,14 +69,38 @@ namespace workspacer
 
         public static int GWL_STYLE = -16;
         public static int GWL_EXSTYLE = -20;
-        [DllImport("user32.dll", EntryPoint="SetWindowLongPtr")]
+        [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
         public static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, uint dwNewLong);
 
+
+        [DllImport("user32.dll", EntryPoint = "GetWindowLong")]
+        public static extern IntPtr GetWindowLong(IntPtr hWnd, int nIndex);
+
         [DllImport("user32.dll", EntryPoint = "GetWindowLongPtr")]
-        public static extern uint GetWindowLongPtr(IntPtr hWnd, int nIndex);
+        public static extern IntPtr GetWindowLongPtr(IntPtr hWnd, int nIndex);
 
-        public static WS GetWindowStyleLongPtr(IntPtr hwnd) { return (WS)GetWindowLongPtr(hwnd, GWL_STYLE); }
-        public static WS_EX GetWindowExStyleLongPtr(IntPtr hwnd) { return (WS_EX)GetWindowLongPtr(hwnd, GWL_EXSTYLE); }
+        public static WS GetWindowStyleLongPtr(IntPtr hwnd)
+        {
+            if (Environment.Is64BitProcess)
+            {
+                return (WS)GetWindowLongPtr(hwnd, GWL_STYLE);
+            }
+            else
+            {
+                return (WS)GetWindowLong(hwnd, GWL_STYLE);
+            }
+        }
 
+        public static WS_EX GetWindowExStyleLongPtr(IntPtr hwnd)
+        {
+            if (Environment.Is64BitProcess)
+            {
+                return (WS_EX)GetWindowLongPtr(hwnd, GWL_EXSTYLE);
+            }
+            else
+            {
+                return (WS_EX)GetWindowLong(hwnd, GWL_EXSTYLE);
+            }
+        }
     }
 }

--- a/src/workspacer.Watcher/ConsoleHelper.cs
+++ b/src/workspacer.Watcher/ConsoleHelper.cs
@@ -33,7 +33,7 @@ namespace workspacer
                 if (handle != IntPtr.Zero)
                 {
                     var style = Win32.GetWindowLongPtr(handle, Win32.GWL_STYLE);
-                    return (style & (uint)Win32.WS.WS_VISIBLE) != 0;
+                    return ((uint)style & (uint)Win32.WS.WS_VISIBLE) != 0;
                 }
                 return false;
             }


### PR DESCRIPTION
From what I can tell, in a 32-bit process `GetWindowLongPtr()` is not available, only `GetWindowLong()`.

Without this patch `workspacer` builds, but when started you get the following runtime-exception which immediately exits the program:

![image](https://user-images.githubusercontent.com/411338/66392052-14530d00-e9cf-11e9-88cf-662046a50201.png)

