### PR TITLE
Reduce nesting

### DIFF
--- a/src/workspacer.Shared/Workspace/Workspace.cs
+++ b/src/workspacer.Shared/Workspace/Workspace.cs
@@ -281,16 +281,16 @@ namespace workspacer
         public void SwapWindowToPoint(IWindow window, int x, int y)
         {
             var windows = GetWindowsForLayout();
-            if (windows.Contains(window))
-            {
-                var index = GetLayoutSlotIndexForPoint(x, y);
-                var destWindow = index != -1 && windows.Count > index ? windows[index] : null;
+            if (!windows.Contains(window))
+                return;
 
-                if (destWindow != null && window != destWindow)
-                {
-                    Logger.Debug("SwapWindowToPoint[{0},{1} - {2}]", x, y, window);
-                    SwapWindows(window, destWindow);
-                }
+            var index = GetLayoutSlotIndexForPoint(x, y);
+            var destWindow = index != -1 && windows.Count > index ? windows[index] : null;
+
+            if (destWindow != null && window != destWindow)
+            {
+                Logger.Debug("SwapWindowToPoint[{0},{1} - {2}]", x, y, window);
+                SwapWindows(window, destWindow);
             }
         }
 
@@ -337,10 +337,18 @@ namespace workspacer
         public void DoLayout()
         {
             var windows = GetWindowsForLayout();
-            if (_context.Enabled)
+            if (!_context.Enabled)
+            {
+                windows.ForEach(w => w.ShowInCurrentState());
+            }
+            else
             {
                 var monitor = _context.WorkspaceContainer.GetCurrentMonitorForWorkspace(this);
-                if (monitor != null)
+                if (monitor == null)
+                {
+                    windows.ForEach(w => w.Hide());
+                }
+                else
                 {
                     windows.ForEach(w => w.ShowInCurrentState());
 
@@ -364,14 +372,6 @@ namespace workspacer
                         }
                     }
                 }
-                else
-                {
-                    windows.ForEach(w => w.Hide());
-                }
-            }
-            else
-            {
-                windows.ForEach(w => w.ShowInCurrentState());
             }
         }
 

--- a/src/workspacer.Shared/Workspace/WorkspaceContainer.cs
+++ b/src/workspacer.Shared/Workspace/WorkspaceContainer.cs
@@ -75,15 +75,15 @@ namespace workspacer
 
         public void AssignWorkspaceToMonitor(IWorkspace workspace, IMonitor monitor)
         {
-            if (monitor != null)
+            if (monitor == null)
+                return;
+
+            if (workspace != null)
             {
-                if (workspace != null)
-                {
-                    workspace.IsIndicating = false;
-                    _lastMonitor[workspace] = GetCurrentMonitorForWorkspace(workspace);
-                }
-                _mtw[monitor] = workspace;
+                workspace.IsIndicating = false;
+                _lastMonitor[workspace] = GetCurrentMonitorForWorkspace(workspace);
             }
+            _mtw[monitor] = workspace;
         }
 
         public IWorkspace GetNextWorkspace(IWorkspace currentWorkspace)


### PR DESCRIPTION
Deeply nested code is hard to read and even harder to reason about.

This PR aims to make the workspacer code more readable by eliminating needless nesting. This is done primarily by inverting existing `if (object != null)`-checks and making exit conditions explicit.