### PR TITLE
Support 64bit processes from 32-bit workspacer

### DIFF
--- a/src/workspacer.Native/Native/WindowsWindow.cs
+++ b/src/workspacer.Native/Native/WindowsWindow.cs
@@ -40,7 +40,15 @@ namespace workspacer
 
                 var process = Process.GetProcesses().FirstOrDefault(p => p.Id == _processId);
                 _processName = process.ProcessName;
-                _processFileName = Path.GetFileName(process.MainModule.FileName);
+
+                try
+                {
+                    _processFileName = Path.GetFileName(process.MainModule.FileName);
+                }
+                catch (System.ComponentModel.Win32Exception)
+                {
+                    _processFileName = "--NA--";
+                }
             }
             catch (Exception)
             {


### PR DESCRIPTION
Right now enumerating Windows from 64-bit processes fails if workspacer is 32-bit.

This is because obtaining the file-name of the process fails, when the module itself is 64-bit. We don't really need this information for anything besides debugging, so ignore errors in obtaining this info.

This closes https://github.com/rickbutton/workspacer/issues/81.