### PR TITLE
Implement IKeybindManager.Unsubscribe(KeyModifiers mod, Keys key)

### DIFF
--- a/src/workspacer.Shared/Keybind/IKeybindManager.cs
+++ b/src/workspacer.Shared/Keybind/IKeybindManager.cs
@@ -45,6 +45,13 @@ namespace workspacer
         void Subscribe(MouseEvent evt, MouseHandler handler, string name);
 
         /// <summary>
+        /// unsubscribe to a specified keybinding
+        /// </summary>
+        /// <param name="mod">desired keyboard modifier to be listened for</param>
+        /// <param name="key">desired keyboard key to be listened for</param>
+        void Unsubscribe(KeyModifiers mod, Keys key);
+
+        /// <summary>
         /// unsubscribe from the specified mouse event
         /// </summary>
         /// <param name="evt">mouse event to be unsubscribed</param>

--- a/src/workspacer/Keybinds/KeybindManager.cs
+++ b/src/workspacer/Keybinds/KeybindManager.cs
@@ -77,6 +77,15 @@ namespace workspacer
             Subscribe(evt, handler, null);
         }
 
+        public void Unsubscribe(KeyModifiers mod, Keys key)
+        {
+            var sub = new Sub(mod, key);
+            if (_kbdSubs.ContainsKey(sub))
+            {
+                _kbdSubs.Remove(sub);
+            }
+        }
+
         public void Unsubscribe(MouseEvent evt)
         {
             if (_mouseSubs.ContainsKey(evt))


### PR DESCRIPTION
This addition allows unbinding default-bound keys without resetting the full configuration, as per the documentation.

This closes https://github.com/rickbutton/workspacer/issues/65.