### PR TITLE
Sub hash collisions

### DIFF
--- a/src/workspacer/Keybinds/KeybindManager.cs
+++ b/src/workspacer/Keybinds/KeybindManager.cs
@@ -41,7 +41,7 @@ namespace workspacer
             _context = context;
             _kbdHook = KbdHook;
             _mouseHook = MouseHook;
-            _kbdSubs = new Dictionary<Sub, NamedBind<KeybindHandler>>(new Sub.SubEqualityComparer());
+            _kbdSubs = new Dictionary<Sub, NamedBind<KeybindHandler>>();
             _mouseSubs = new Dictionary<MouseEvent, NamedBind<MouseHandler>>();
 
             SubscribeDefaults();

--- a/src/workspacer/Keybinds/Sub.cs
+++ b/src/workspacer/Keybinds/Sub.cs
@@ -70,7 +70,7 @@ namespace workspacer
                 modifiers += 8;
             }
 
-            return modifiers + 256 + (int)obj.Keys;
+            return modifiers + 256 * (int)obj.Keys;
         }
     }
 }

--- a/src/workspacer/Keybinds/Sub.cs
+++ b/src/workspacer/Keybinds/Sub.cs
@@ -13,59 +13,64 @@ namespace workspacer
             Keys = key;
         }
 
-        public sealed class SubEqualityComparer : IEqualityComparer<Sub>
+        public override bool Equals(object obj)
         {
-            bool IEqualityComparer<Sub>.Equals(Sub x, Sub y)
+            var x = this;
+            var y = obj as Sub;
+            if (y == null)
             {
-                if (((x.Modifiers & KeyModifiers.Alt) != KeyModifiers.None ||
-                     (y.Modifiers & KeyModifiers.Alt) != KeyModifiers.None) &&
-                    (x.Modifiers & KeyModifiers.Alt & y.Modifiers) == KeyModifiers.None)
-                {
-                    return false;
-                }
-                if (((x.Modifiers & KeyModifiers.Control) != KeyModifiers.None ||
-                     (y.Modifiers & KeyModifiers.Control) != KeyModifiers.None) &&
-                    (x.Modifiers & KeyModifiers.Control & y.Modifiers) == KeyModifiers.None)
-                {
-                    return false;
-                }
-                if (((x.Modifiers & KeyModifiers.Shift) != KeyModifiers.None ||
-                     (y.Modifiers & KeyModifiers.Shift) != KeyModifiers.None) &&
-                    (x.Modifiers & KeyModifiers.Shift & y.Modifiers) == KeyModifiers.None)
-                {
-                    return false;
-                }
-                if (((x.Modifiers & KeyModifiers.Win) != KeyModifiers.None ||
-                     (y.Modifiers & KeyModifiers.Win) != KeyModifiers.None) &&
-                    (x.Modifiers & KeyModifiers.Win & y.Modifiers) == KeyModifiers.None)
-                {
-                    return false;
-                }
-                return x.Keys == y.Keys;
+                return false;
             }
 
-            int IEqualityComparer<Sub>.GetHashCode(Sub obj)
+            if (((x.Modifiers & KeyModifiers.Alt) != KeyModifiers.None ||
+                 (y.Modifiers & KeyModifiers.Alt) != KeyModifiers.None) &&
+                (x.Modifiers & KeyModifiers.Alt & y.Modifiers) == KeyModifiers.None)
             {
-                var modifiers = 0;
-                if ((obj.Modifiers & KeyModifiers.Alt) != KeyModifiers.None)
-                {
-                    modifiers += 1;
-                }
-                if ((obj.Modifiers & KeyModifiers.Control) != KeyModifiers.None)
-                {
-                    modifiers += 2;
-                }
-                if ((obj.Modifiers & KeyModifiers.Shift) != KeyModifiers.None)
-                {
-                    modifiers += 4;
-                }
-                if ((obj.Modifiers & KeyModifiers.Win) != KeyModifiers.None)
-                {
-                    modifiers += 8;
-                }
-
-                return modifiers + 256 + (int)obj.Keys;
+                return false;
             }
+            if (((x.Modifiers & KeyModifiers.Control) != KeyModifiers.None ||
+                 (y.Modifiers & KeyModifiers.Control) != KeyModifiers.None) &&
+                (x.Modifiers & KeyModifiers.Control & y.Modifiers) == KeyModifiers.None)
+            {
+                return false;
+            }
+            if (((x.Modifiers & KeyModifiers.Shift) != KeyModifiers.None ||
+                 (y.Modifiers & KeyModifiers.Shift) != KeyModifiers.None) &&
+                (x.Modifiers & KeyModifiers.Shift & y.Modifiers) == KeyModifiers.None)
+            {
+                return false;
+            }
+            if (((x.Modifiers & KeyModifiers.Win) != KeyModifiers.None ||
+                 (y.Modifiers & KeyModifiers.Win) != KeyModifiers.None) &&
+                (x.Modifiers & KeyModifiers.Win & y.Modifiers) == KeyModifiers.None)
+            {
+                return false;
+            }
+            return x.Keys == y.Keys;
+        }
+
+        public override int GetHashCode()
+        {
+            var obj = this;
+            var modifiers = 0;
+            if ((obj.Modifiers & KeyModifiers.Alt) != KeyModifiers.None)
+            {
+                modifiers += 1;
+            }
+            if ((obj.Modifiers & KeyModifiers.Control) != KeyModifiers.None)
+            {
+                modifiers += 2;
+            }
+            if ((obj.Modifiers & KeyModifiers.Shift) != KeyModifiers.None)
+            {
+                modifiers += 4;
+            }
+            if ((obj.Modifiers & KeyModifiers.Win) != KeyModifiers.None)
+            {
+                modifiers += 8;
+            }
+
+            return modifiers + 256 + (int)obj.Keys;
         }
     }
 }

--- a/workspacer.Tests/Properties/AssemblyInfo.cs
+++ b/workspacer.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("workspacer.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("workspacer.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("36884a7d-b921-4f6d-a324-239d79af38f2")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/workspacer.Tests/SubTests.cs
+++ b/workspacer.Tests/SubTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace workspacer.Tests
+{
+    public class SubTests
+    {
+        [Fact]
+        public void LeftCtrl_Does_Not_Equal_RightControl()
+        {
+            TestEquality(KeyModifiers.LControl, KeyModifiers.RControl, KeyModifiers.Control);
+        }
+
+        [Fact]
+        public void RightAlt_Does_Not_Equal_LeftAlt()
+        {
+            TestEquality(KeyModifiers.LAlt, KeyModifiers.RAlt, KeyModifiers.Alt);
+        }
+
+        [Fact]
+        public void RightWin_Does_Not_Equal_LeftWin()
+        {
+            TestEquality(KeyModifiers.LWin, KeyModifiers.RWin, KeyModifiers.Win);
+        }
+
+        private void TestEquality(KeyModifiers lKey, KeyModifiers rKey, KeyModifiers bothKey)
+        {
+            var left = new Sub(lKey, Keys.D1);
+            var right = new Sub(rKey, Keys.D1);
+            var both = new Sub(bothKey, Keys.D1);
+
+            Assert.NotEqual(left, right);
+            Assert.Equal(left, both);
+            Assert.Equal(right, both);
+        }
+    }
+}

--- a/workspacer.Tests/SubTests.cs
+++ b/workspacer.Tests/SubTests.cs
@@ -37,5 +37,42 @@ namespace workspacer.Tests
             Assert.Equal(left, both);
             Assert.Equal(right, both);
         }
+
+        [Fact]
+        public void LeftCtrl_RightCtrl_And_Ctrl_Has_Same_HashCode()
+        {
+            TestHashEquality(KeyModifiers.LControl, KeyModifiers.RControl, KeyModifiers.Control);
+        }
+
+        [Fact]
+        public void RightAlt_LeftAlt_And_Alt_Has_Same_HashCode()
+        {
+            TestHashEquality(KeyModifiers.LAlt, KeyModifiers.RAlt, KeyModifiers.Alt);
+        }
+
+        [Fact]
+        public void RightWin_LeftWin_And_WinHas_Same_HashCode()
+        {
+            TestHashEquality(KeyModifiers.LWin, KeyModifiers.RWin, KeyModifiers.Win);
+        }
+
+        private void TestHashEquality(KeyModifiers lKey, KeyModifiers rKey, KeyModifiers bothKey)
+        {
+            var left = new Sub(lKey, Keys.D1).GetHashCode();
+            var right = new Sub(rKey, Keys.D1).GetHashCode();
+            var both = new Sub(bothKey, Keys.D1).GetHashCode();
+
+            Assert.Equal(left, both);
+            Assert.Equal(left, right);
+        }
+
+        [Fact]
+        public void Does_Not_Have_Hash_Collisions_Between_Different_Keys()
+        {
+            var subHash1 = new Sub(KeyModifiers.None, Keys.D2).GetHashCode();
+            var subHash2 = new Sub(KeyModifiers.Alt, Keys.D1).GetHashCode();
+
+            Assert.NotEqual(subHash1, subHash2);
+        }
     }
 }

--- a/workspacer.Tests/app.config
+++ b/workspacer.Tests/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/workspacer.Tests/packages.config
+++ b/workspacer.Tests/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit" version="2.4.1" targetFramework="net472" />
+  <package id="xunit.abstractions" version="2.0.3" targetFramework="net472" />
+  <package id="xunit.analyzers" version="0.10.0" targetFramework="net472" />
+  <package id="xunit.assert" version="2.4.1" targetFramework="net472" />
+  <package id="xunit.core" version="2.4.1" targetFramework="net472" />
+  <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net472" />
+  <package id="xunit.extensibility.execution" version="2.4.1" targetFramework="net472" />
+</packages>

--- a/workspacer.Tests/workspacer.Tests.csproj
+++ b/workspacer.Tests/workspacer.Tests.csproj
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.core.2.4.1\build\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.4.1\build\xunit.core.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{36884A7D-B921-4F6D-A324-239D79AF38F2}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>workspacer.Tests</RootNamespace>
+    <AssemblyName>workspacer.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.4.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.4.1\lib\net452\xunit.core.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.4.1\lib\net452\xunit.execution.desktop.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SubTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\workspacer.Shared\workspacer.Shared.csproj">
+      <Project>{d13fd20b-e571-438d-b122-e24bc5a1384f}</Project>
+      <Name>workspacer.Shared</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\src\workspacer\workspacer.csproj">
+      <Project>{d89294e0-eb76-440e-835c-ccd1e4cf6933}</Project>
+      <Name>workspacer</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\xunit.analyzers.0.10.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.core.2.4.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.4.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.1\build\xunit.core.targets'))" />
+  </Target>
+  <Import Project="..\packages\xunit.core.2.4.1\build\xunit.core.targets" Condition="Exists('..\packages\xunit.core.2.4.1\build\xunit.core.targets')" />
+</Project>

--- a/workspacer.sln
+++ b/workspacer.sln
@@ -25,6 +25,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "workspacer.FocusIndicator",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "workspacer.Shared.Tests", "src\workspacer.Shared.Tests\workspacer.Shared.Tests.csproj", "{C69C243C-E40C-46CC-8599-DC7CC39F4C6F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "workspacer.Tests", "workspacer.Tests\workspacer.Tests.csproj", "{36884A7D-B921-4F6D-A324-239D79AF38F2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -131,6 +133,18 @@ Global
 		{C69C243C-E40C-46CC-8599-DC7CC39F4C6F}.Release|x64.Build.0 = Release|Any CPU
 		{C69C243C-E40C-46CC-8599-DC7CC39F4C6F}.Release|x86.ActiveCfg = Release|Any CPU
 		{C69C243C-E40C-46CC-8599-DC7CC39F4C6F}.Release|x86.Build.0 = Release|Any CPU
+		{36884A7D-B921-4F6D-A324-239D79AF38F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36884A7D-B921-4F6D-A324-239D79AF38F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36884A7D-B921-4F6D-A324-239D79AF38F2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{36884A7D-B921-4F6D-A324-239D79AF38F2}.Debug|x64.Build.0 = Debug|Any CPU
+		{36884A7D-B921-4F6D-A324-239D79AF38F2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{36884A7D-B921-4F6D-A324-239D79AF38F2}.Debug|x86.Build.0 = Debug|Any CPU
+		{36884A7D-B921-4F6D-A324-239D79AF38F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36884A7D-B921-4F6D-A324-239D79AF38F2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36884A7D-B921-4F6D-A324-239D79AF38F2}.Release|x64.ActiveCfg = Release|Any CPU
+		{36884A7D-B921-4F6D-A324-239D79AF38F2}.Release|x64.Build.0 = Release|Any CPU
+		{36884A7D-B921-4F6D-A324-239D79AF38F2}.Release|x86.ActiveCfg = Release|Any CPU
+		{36884A7D-B921-4F6D-A324-239D79AF38F2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- Fix hash-collisions in `Sub`-class.
- Add new test-project `workspacer.Tests` and unit-tests for `Sub`-class

 This closes https://github.com/rickbutton/workspacer/issues/87.
