### PR TITLE
fix(Shared): Exposed ShowKeybindDialog method to config

### DIFF
--- a/src/workspacer.Shared/Keybind/IKeybindManager.cs
+++ b/src/workspacer.Shared/Keybind/IKeybindManager.cs
@@ -67,5 +67,10 @@ namespace workspacer
         /// unsubscribe from all keybindings and mouse events
         /// </summary>
         void UnsubscribeAll();
+
+        /// <summary>
+        /// show/hide keybind help
+        /// </summary>
+        void ShowKeybindDialog();
     }
 }


### PR DESCRIPTION
Currently, user created configuration files don't have access to the `context.Keybinds.ShowKeybindDialog()` method when adding custom hotkeys. This small fix should alleviate that problem. 

Use case is primarily for configuration files which start from scratch by using `context.Keybinds.UnsubscribeAll()` and need to add some defaults back in.  