### PR TITLE
Remember current workspace before switching

### DIFF
--- a/src/workspacer.Shared/Workspace/IWorkspaceManager.cs
+++ b/src/workspacer.Shared/Workspace/IWorkspaceManager.cs
@@ -20,6 +20,7 @@ namespace workspacer
         void SwitchToWindow(IWindow window);
         void SwitchToWorkspace(int index);
         void SwitchToWorkspace(IWorkspace workspace);
+        void SwitchToLastFocusedWorkspace();
         void SwitchMonitorToWorkspace(int monitorIndex, int workspaceIndex);
         void SwitchToNextWorkspace();
         void SwitchToPreviousWorkspace();

--- a/src/workspacer/Keybinds/KeybindManager.cs
+++ b/src/workspacer/Keybinds/KeybindManager.cs
@@ -290,6 +290,9 @@ namespace workspacer
             Subscribe(mod, Keys.Right,
                 () => _context.Workspaces.SwitchToNextWorkspace(), "switch to next workspace");
 
+            Subscribe(mod, Keys.Oemtilde,
+                () => _context.Workspaces.SwitchToLastFocusedWorkspace(), "switch to last focused workspace");
+
             Subscribe(mod, Keys.W,
                 () => _context.Workspaces.SwitchFocusedMonitor(0), "focus monitor 1");
 

--- a/src/workspacer/Workspace/WorkspaceManager.cs
+++ b/src/workspacer/Workspace/WorkspaceManager.cs
@@ -52,7 +52,6 @@ namespace workspacer
             Logger.Debug("SwitchToWorkspace({0})", index);
             var currentWorkspace = FocusedWorkspace;
             var targetWorkspace = _context.WorkspaceContainer.GetWorkspaceAtIndex(currentWorkspace, index);
-            _lastWorkspace = currentWorkspace;
             SwitchToWorkspace(targetWorkspace);
         }
 

--- a/src/workspacer/Workspace/WorkspaceManager.cs
+++ b/src/workspacer/Workspace/WorkspaceManager.cs
@@ -15,6 +15,7 @@ namespace workspacer
         private static Logger Logger = Logger.Create();
 
         private IConfigContext _context;
+        private IWorkspace _lastWorkspace;
         public IWorkspace FocusedWorkspace => _context.WorkspaceContainer
             .GetWorkspaceForMonitor(_context.MonitorContainer.FocusedMonitor);
 
@@ -40,6 +41,7 @@ namespace workspacer
             if (_windowsToWorkspaces.ContainsKey(window))
             {
                 var workspace = _windowsToWorkspaces[window];
+                _lastWorkspace = workspace;
                 SwitchToWorkspace(workspace);
                 window.Focus();
             }
@@ -50,6 +52,7 @@ namespace workspacer
             Logger.Debug("SwitchToWorkspace({0})", index);
             var currentWorkspace = FocusedWorkspace;
             var targetWorkspace = _context.WorkspaceContainer.GetWorkspaceAtIndex(currentWorkspace, index);
+            _lastWorkspace = currentWorkspace;
             SwitchToWorkspace(targetWorkspace);
         }
 
@@ -65,6 +68,7 @@ namespace workspacer
 
                 if (targetWorkspace != currentWorkspace)
                 {
+                    _lastWorkspace = currentWorkspace;
                     _context.WorkspaceContainer.AssignWorkspaceToMonitor(currentWorkspace, sourceMonitor);
                     _context.WorkspaceContainer.AssignWorkspaceToMonitor(targetWorkspace, destMonitor);
 
@@ -78,6 +82,14 @@ namespace workspacer
             }
         }
 
+        public void SwitchToLastFocusedWorkspace()
+        {
+            Logger.Debug("SwitchToLastWorkspace({0})", _lastWorkspace);
+            var targetWorkspace = _lastWorkspace;
+            _lastWorkspace = FocusedWorkspace;
+            SwitchToWorkspace(targetWorkspace);
+        }
+
         public void SwitchMonitorToWorkspace(int monitorIndex, int workspaceIndex)
         {
             Logger.Debug("SwitchMonitorToWorkspace(monitorIndex: {0}, workspaceIndex: {1})", monitorIndex, workspaceIndex);
@@ -89,6 +101,7 @@ namespace workspacer
             var targetWorkspace = _context.WorkspaceContainer.GetWorkspaceAtIndex(currentWorkspace, workspaceIndex);
             var sourceMonitor = _context.WorkspaceContainer.GetCurrentMonitorForWorkspace(targetWorkspace);
 
+            _lastWorkspace = currentWorkspace;
             _context.WorkspaceContainer.AssignWorkspaceToMonitor(currentWorkspace, sourceMonitor);
             _context.WorkspaceContainer.AssignWorkspaceToMonitor(targetWorkspace, destMonitor);
 
@@ -108,6 +121,7 @@ namespace workspacer
             var targetWorkspace = _context.WorkspaceContainer.GetNextWorkspace(currentWorkspace);
             var sourceMonitor = _context.WorkspaceContainer.GetCurrentMonitorForWorkspace(targetWorkspace);
 
+            _lastWorkspace = currentWorkspace;
             _context.WorkspaceContainer.AssignWorkspaceToMonitor(currentWorkspace, sourceMonitor);
             _context.WorkspaceContainer.AssignWorkspaceToMonitor(targetWorkspace, destMonitor);
 
@@ -127,6 +141,7 @@ namespace workspacer
             var targetWorkspace = _context.WorkspaceContainer.GetPreviousWorkspace(currentWorkspace);
             var sourceMonitor = _context.WorkspaceContainer.GetCurrentMonitorForWorkspace(targetWorkspace);
 
+            _lastWorkspace = currentWorkspace;
             _context.WorkspaceContainer.AssignWorkspaceToMonitor(currentWorkspace, sourceMonitor);
             _context.WorkspaceContainer.AssignWorkspaceToMonitor(targetWorkspace, destMonitor);
 

--- a/src/workspacer/Workspace/WorkspaceManager.cs
+++ b/src/workspacer/Workspace/WorkspaceManager.cs
@@ -41,7 +41,6 @@ namespace workspacer
             if (_windowsToWorkspaces.ContainsKey(window))
             {
                 var workspace = _windowsToWorkspaces[window];
-                _lastWorkspace = workspace;
                 SwitchToWorkspace(workspace);
                 window.Focus();
             }


### PR DESCRIPTION
This commit adds a `_lastWorkspace` variable to WorkspaceManager. This
variable is set to the currently focused workspace just prior to
switching to a different workspace.

This allows implementation of a `SwitchToLastFocusedWorkspace()` method
that will switch to the workspace stored in `_lastWorkspace`. This
allows switching back and forth between the currently focused workspace
and the previously focused workspace on each call.

A default keybind is added to call this method via `mod+tilde`.