### PR TITLE
Added features to the `TitleWidget` Plugin

### DIFF
--- a/src/workspacer.Bar/Widgets/TitleWidget.cs
+++ b/src/workspacer.Bar/Widgets/TitleWidget.cs
@@ -9,6 +9,8 @@ namespace workspacer.Bar.Widgets
     public class TitleWidget : BarWidgetBase
     {
         public Color MonitorHasFocusColor { get; set; } = Color.Yellow;
+        public bool IsShortTitle { get; set; } = false;
+        public string NoWindowMessage { get; set; } = "No Window";
 
         public override IBarWidgetPart[] GetParts()
         {
@@ -19,10 +21,18 @@ namespace workspacer.Bar.Widgets
 
             if (window != null)
             {
-                return Parts(Part(window.Title, color));
+                if (!IsShortTitle)
+                {
+                    return Parts(Part(window.Title, color));
+                }
+                else 
+                {
+                        string ShortTitle = window.Title.Split("-").Last();
+                        return Parts(Part(ShortTitle, color));
+                }
             } else
             {
-                return Parts(Part("no windows", color));
+                return Parts(Part(NoWindowMessage, color));
             }
         }
 

--- a/src/workspacer.Bar/Widgets/TitleWidget.cs
+++ b/src/workspacer.Bar/Widgets/TitleWidget.cs
@@ -10,7 +10,7 @@ namespace workspacer.Bar.Widgets
     {
         public Color MonitorHasFocusColor { get; set; } = Color.Yellow;
         public bool IsShortTitle { get; set; } = false;
-        public string NoWindowMessage { get; set; } = "No Window";
+        public string NoWindowMessage { get; set; } = "No Windows";
 
         public override IBarWidgetPart[] GetParts()
         {


### PR DESCRIPTION
Made 2 changes to the `TitleWidget`:

1. The user can now choose to show **only the program name** via the boolean choice of `IsShortTitle`. There are some programs where this does not work as the separator between window contents and programs is not the same everywhere (i.e. MS Teams using ` |` and not `-`), but this seems quite rare.

2. Allows the user to set a custom message for workspaces without any windows, defaults to **"No Windows"**.