### PR TITLE
KeybindManager changes 

### DIFF
--- a/src/workspacer/Keybinds/KeybindManager.cs
+++ b/src/workspacer/Keybinds/KeybindManager.cs
@@ -25,7 +25,6 @@ namespace workspacer
             }
         }
 
-        private Logger Logger = Logger.Create();
 
         private Win32.HookProc _kbdHook;
         private Win32.HookProc _mouseHook;
@@ -59,6 +58,13 @@ namespace workspacer
         public void Subscribe(KeyModifiers mod, Keys key, KeybindHandler handler, string name)
         {
             var sub = new Sub(mod, key);
+            var test = new LauncherResponse();
+            if (_kbdSubs.ContainsKey(sub))
+            {
+                Exception keyCombinationAlreadyAssigned = new Exception($" The Key Combination `{mod}-{key}` is already bound to action: `{name}`");
+
+                _context.QuitWithException(keyCombinationAlreadyAssigned);
+            }
             _kbdSubs[sub] = new NamedBind<KeybindHandler>(handler, name);
         }
 
@@ -205,7 +211,7 @@ namespace workspacer
             Subscribe(MouseEvent.LButtonDown,
                 () => _context.Workspaces.SwitchFocusedMonitorToMouseLocation());
 
-            Subscribe(mod | KeyModifiers.LShift, Keys.E,
+            Subscribe(mod, Keys.Escape,
                 () => _context.Enabled = !_context.Enabled, "toggle enable/disable");
 
             Subscribe(mod | KeyModifiers.LShift, Keys.C,

--- a/src/workspacer/Keybinds/KeybindManager.cs
+++ b/src/workspacer/Keybinds/KeybindManager.cs
@@ -59,32 +59,22 @@ namespace workspacer
 
         public void ShowKeybindWarning(string warningMessage)
         {
-            if (_keybindWarning == null)
+            _keybindWarning = new TextBlockMessage("workspacer keybinds", "Warning, duplicate keybinds!", warningMessage, new List<Tuple<string, Action>>()
             {
-                _keybindWarning = new TextBlockMessage("workspacer keybinds", "Warning, duplicate keybinds!", warningMessage, new List<Tuple<string, Action>>()
-                {
-                    new Tuple<string, Action>("ok", () => { }),
-                });
-            }
-
-            if (_keybindWarning.Visible)
-            {
-                _keybindWarning.Hide();
-            }
-            else
-            {
-                _keybindWarning.Show();
-            }
+                new Tuple<string, Action>("ok", () => { }),
+            });
+          
+            _keybindWarning.Show();
+            
         }
 
         public void Subscribe(KeyModifiers mod, Keys key, KeybindHandler handler, string name)
         {
             var sub = new Sub(mod, key);
-            var test = new LauncherResponse();
             if (_kbdSubs.ContainsKey(sub))
             {
-                Logger.Error($" The Key Combination `{mod}-{key}` is already bound to action: `{name}`");
-               string warning = @$" The Key Combination `{mod}-{key}` is already bound to action: `{name}` To fix this go into your config file and compare assignments of hotkeys
+               Logger.Error($" The Key Combination `{mod}-{key}` is already bound to action: `{name}`");
+               string warning = @$" The Key Combination `{mod}-{key}` is already bound to action: `{name}`. To fix this go into your config file and compare assignments of hotkeys
 You can either change your custom hotkey or reassign the default hotkey";
 
                 ShowKeybindWarning(warning);


### PR DESCRIPTION
Quick-fix for #121 
1. added error checking for duplicate assignment, throws exception when a user tries to assign an already used key combination
2. removed unused logger
3. edited default keybind for ` toggle enable/disable` to not conflict with `move focused window to monitor 2`. Should be an intuitive shortcut