### PR TITLE
Bugfix BatteryWidget.cs

### DIFF
--- a/src/workspacer.Bar/Widgets/BatteryWidget.cs
+++ b/src/workspacer.Bar/Widgets/BatteryWidget.cs
@@ -40,13 +40,17 @@ namespace workspacer.Bar.Widgets
                     return Parts(Part(currentBatteryCharge.ToString("#0%"), HighChargeColor));
                 }
             }
-
-            public override void Initialize()
+            else
             {
-                _timer = new System.Timers.Timer(Interval);
-                _timer.Elapsed += (s, e) => Context.MarkDirty();
-                _timer.Enabled = true;
+                return Parts(currentBatteryCharge.ToString("#0%"));
             }
+        }
+
+        public override void Initialize()
+        {
+            _timer = new System.Timers.Timer(Interval);
+            _timer.Elapsed += (s, e) => Context.MarkDirty();
+            _timer.Enabled = true;
         }
     }
 }


### PR DESCRIPTION
The else loop is not redundant since it is an option to the BatteryWidget.Parts() class
Just tested this configuration on my setup, earlier PR had a bug when diff with my local setup :(