### PR TITLE
added the corrected documentation to change keybinding config

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -101,11 +101,11 @@ context.Keybinds.Subscribe(mod, Keys.Y, () => Console.WriteLine("Y was pressed")
 if you want to remove a keybinding that already exists, you can unsubscribe from it:
 
 ```csharp
-context.Keybindings.Unsubscribe(mod, Keys.Y);
+context.Keybinds.Unsubscribe(mod, Keys.Y);
 ```
 
 finally, you can remove all of the default keybindings via:
 
 ```csharp
-context.Keybindings.UnsubscribeAll();
+context.Keybinds.UnsubscribeAll();
 ```

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -88,11 +88,15 @@ note that `DefaultMenu` contains a useful set of default items. if you don't wan
 
 workspacer subscribes to the [default set of keybindings](/keybindings) automatically for you. if you want to add additional keybindings, or override an existing one, you can do the following:
 
+Define the mod key the to the default key or ignore this step if you have already defined the mod key
+
+```csharp
+KeyModifiers mod = KeyModifiers.Alt;
+```
+
 ```csharp
 context.Keybinds.Subscribe(mod, Keys.Y, () => Console.WriteLine("Y was pressed"))
 ```
-
-where `mod` is a KeyModifiers value (`mod` is already defined as `KeyModifiers.Alt` in the default config, so you should be able to reuse it).
 
 if you want to remove a keybinding that already exists, you can unsubscribe from it:
 


### PR DESCRIPTION
The current custom keybinding documentation is outdated in two aspects
1. The current documentation for modifying or adding `Keybinds `is incorrectly listed as `Keybindings`.
The examples are changed from 
```csharp
context.Keybindings.Unsubscribe(mod, Keys.Y);
//TO
context.Keybinds.Unsubscribe(mod, Keys.Y);
```

2. The mod key is not defined so the examples exit with an error

This results in an error when workspacer starts
```
Microsoft.CodeAnalysis.Scripting.CompilationErrorException: (21,32): error CS0103: The name 'mod' does not exist in the current context
   at Microsoft.CodeAnalysis.Scripting.ScriptBuilder.ThrowIfAnyCompilationErrors(DiagnosticBag diagnostics, DiagnosticFormatter formatter)
   at Microsoft.CodeAnalysis.Scripting.ScriptBuilder.CreateExecutor[T](ScriptCompiler compiler, Compilation compilation, Boolean emitDebugInformation, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.Scripting.Script`1.GetExecutor(CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.Scripting.Script`1.RunAsync(Object globals, Func`2 catchException, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.Scripting.Script`1.RunAsync(Object globals, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.CSharp.Scripting.CSharpScript.RunAsync[T](String code, ScriptOptions options, Object globals, Type globalsType, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.CSharp.Scripting.CSharpScript.EvaluateAsync[T](String code, ScriptOptions options, Object globals, Type globalsType, CancellationToken cancellationToken)
   at workspacer.ConfigHelper.DoConfig(IConfigContext context)
   at workspacer.workspacer.Start()
   at workspacer.Program.Run()
   at workspacer.Program.Main(String[] args)
```

This has been fixed by 
```csharp
KeyModifiers mod = KeyModifiers.Alt;
```
