### PR TITLE
Fix the gap by calculating offset

### DIFF
--- a/src/workspacer.Native/Native/WindowsDeferPosHandle.cs
+++ b/src/workspacer.Native/Native/WindowsDeferPosHandle.cs
@@ -67,7 +67,12 @@ namespace workspacer
                 _toNormal.Add(window);
             }
 
-            Win32.DeferWindowPos(_info, window.Handle, IntPtr.Zero, location.X, location.Y, location.Width, location.Height, flags);
+            int X = location.X + window.Offset.X;
+            int Y = location.Y + window.Offset.Y;
+            int Width = location.Width + window.Offset.Width;
+            int Height = location.Height + window.Offset.Height;
+
+            Win32.DeferWindowPos(_info, window.Handle, IntPtr.Zero, X, Y, Width, Height, flags);
         }
     }
 }

--- a/src/workspacer.Native/Native/WindowsDeferPosHandle.cs
+++ b/src/workspacer.Native/Native/WindowsDeferPosHandle.cs
@@ -67,10 +67,12 @@ namespace workspacer
                 _toNormal.Add(window);
             }
 
-            int X = location.X + window.Offset.X;
-            int Y = location.Y + window.Offset.Y;
-            int Width = location.Width + window.Offset.Width;
-            int Height = location.Height + window.Offset.Height;
+            // Calculate final position for window
+            var offset = window.Offset;
+            int X = location.X + offset.X;
+            int Y = location.Y + offset.Y;
+            int Width = location.Width + offset.Width;
+            int Height = location.Height + offset.Height;
 
             Win32.DeferWindowPos(_info, window.Handle, IntPtr.Zero, X, Y, Width, Height, flags);
         }

--- a/src/workspacer.Native/Native/WindowsWindow.cs
+++ b/src/workspacer.Native/Native/WindowsWindow.cs
@@ -78,7 +78,8 @@ namespace workspacer
             {
                 var buffer = new StringBuilder(255);
                 Win32.GetClassName(_handle, buffer, buffer.Capacity + 1);
-                return buffer.ToString();            }
+                return buffer.ToString();
+            }
         }
 
         public IWindowLocation Location
@@ -98,7 +99,55 @@ namespace workspacer
                     state = WindowState.Maximized;
                 }
 
-                return new WindowLocation(rect.Left, rect.Top, rect.Right - rect.Left, rect.Bottom - rect.Top, state);
+                int X = rect.Left;
+                int Y = rect.Top;
+                int Width = rect.Right - rect.Left;
+                int Height = rect.Bottom - rect.Top;
+
+                return new WindowLocation(X, Y, Width, Height, state);
+            }
+        }
+
+        public IWindowLocation Offset
+        {
+            get
+            {
+                WindowState state = WindowState.Normal;
+                if (IsMinimized)
+                {
+                    state = WindowState.Minimized;
+                }
+                else if (IsMaximized)
+                {
+                    state = WindowState.Maximized;
+                }
+
+                // Window Rect via GetWindowRect
+                Win32.Rect rect1 = new Win32.Rect();
+                Win32.GetWindowRect(_handle, ref rect1);
+
+                int X1 = rect1.Left;
+                int Y1 = rect1.Top;
+                int Width1 = rect1.Right - rect1.Left;
+                int Height1 = rect1.Bottom - rect1.Top;
+
+                // Window Rect via DwmGetWindowAttribute
+                Win32.Rect rect2 = new Win32.Rect();
+                int size = Marshal.SizeOf(typeof(Win32.Rect));
+                Win32.DwmGetWindowAttribute(_handle, (int)Win32.DwmWindowAttribute.DWMWA_EXTENDED_FRAME_BOUNDS, out rect2, size);
+
+                int X2 = rect2.Left;
+                int Y2 = rect2.Top;
+                int Width2 = rect2.Right - rect2.Left;
+                int Height2 = rect2.Bottom - rect2.Top;
+
+                // Offset
+                int X = X1 - X2;
+                int Y = Y1 - Y2;
+                int Width = Width1 - Width2;
+                int Height = Height1 - Height2;
+
+                return new WindowLocation(X, Y, Width, Height, state);
             }
         }
 
@@ -110,7 +159,7 @@ namespace workspacer
         {
             get
             {
-                return _didManualHide || 
+                return _didManualHide ||
                     (!Win32Helper.IsCloaked(_handle) &&
                        Win32Helper.IsAppWindow(_handle) &&
                        Win32Helper.IsAltTabWindow(_handle));

--- a/src/workspacer.Native/Native/WindowsWindow.cs
+++ b/src/workspacer.Native/Native/WindowsWindow.cs
@@ -99,29 +99,14 @@ namespace workspacer
                     state = WindowState.Maximized;
                 }
 
-                int X = rect.Left;
-                int Y = rect.Top;
-                int Width = rect.Right - rect.Left;
-                int Height = rect.Bottom - rect.Top;
-
-                return new WindowLocation(X, Y, Width, Height, state);
+                return new WindowLocation(rect.Left, rect.Top, rect.Right - rect.Left, rect.Bottom - rect.Top, state);
             }
         }
 
-        public IWindowLocation Offset
+        public Rectangle Offset
         {
             get
             {
-                WindowState state = WindowState.Normal;
-                if (IsMinimized)
-                {
-                    state = WindowState.Minimized;
-                }
-                else if (IsMaximized)
-                {
-                    state = WindowState.Maximized;
-                }
-
                 // Window Rect via GetWindowRect
                 Win32.Rect rect1 = new Win32.Rect();
                 Win32.GetWindowRect(_handle, ref rect1);
@@ -141,13 +126,13 @@ namespace workspacer
                 int Width2 = rect2.Right - rect2.Left;
                 int Height2 = rect2.Bottom - rect2.Top;
 
-                // Offset
+                // Calculate offset
                 int X = X1 - X2;
                 int Y = Y1 - Y2;
                 int Width = Width1 - Width2;
                 int Height = Height1 - Height2;
 
-                return new WindowLocation(X, Y, Width, Height, state);
+                return new Rectangle(X, Y, Width, Height);
             }
         }
 

--- a/src/workspacer.Shared/Window/IWindow.cs
+++ b/src/workspacer.Shared/Window/IWindow.cs
@@ -13,6 +13,7 @@ namespace workspacer
         string Title { get; }
         string Class { get; }
         IWindowLocation Location { get; }
+        IWindowLocation Offset { get; }
 
         int ProcessId { get; }
         string ProcessFileName { get; }

--- a/src/workspacer.Shared/Window/IWindow.cs
+++ b/src/workspacer.Shared/Window/IWindow.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Drawing;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -13,7 +14,7 @@ namespace workspacer
         string Title { get; }
         string Class { get; }
         IWindowLocation Location { get; }
-        IWindowLocation Offset { get; }
+        Rectangle Offset { get; }
 
         int ProcessId { get; }
         string ProcessFileName { get; }


### PR DESCRIPTION
As discussed here: https://github.com/rickbutton/workspacer/issues/139, this PR fixes issues where gaps are present when laying out windows.

I now have it where all the gaps are basically gone using a combination of `GetWindowRect` and `DwmGetWindowAttribute` to compute an offset to apply to the final window position.

With this change windows that previously had gaps on the Left, Right and Bottom (like Explorer, Firefox, Edge, and Terminal) no longer do.