### PR TITLE
System Tray Icon is removed properly on exit

### DIFF
--- a/src/workspacer/ConfigContext.cs
+++ b/src/workspacer/ConfigContext.cs
@@ -148,7 +148,7 @@ namespace workspacer
             var str = JsonConvert.SerializeObject(response);
             _pipeServer.SendResponse(str);
         }
-        
+
         public void Restart()
         {
             SaveState();
@@ -187,6 +187,7 @@ namespace workspacer
 
         public void CleanupAndExit()
         {
+            SystemTray.Destroy();
             Application.Exit();
             Environment.Exit(0);
         }


### PR DESCRIPTION
I noticed when restarting Workspacer or quitting through the right click function on the System Tray icon, that the icon wasn't properly being disposed as you can see by this image.
![Screenshot 2020-12-03 111033](https://user-images.githubusercontent.com/47256571/101009950-11639600-355a-11eb-9db1-1998fcd0910d.png)

Looking through the code, this function was implemented in SystemTrayManager but just wasn't being called on quit. 
Additionally, if Workspacer is killed via task manager or pressing stop whilst debugging, the Icon remains. However testing this with other tray utilising programs (keepassxc and VLC I tested) the same thing happened with them.