### PR TITLE
Add CNAME on deploy

### DIFF
--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -60,3 +60,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
+          cname: workspacer.org

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-workspacer.org


### PR DESCRIPTION
CNAME would normally be wiped every page deploy without this.