### PR TITLE
Remove title change event to prevent flickering in some apps

### DIFF
--- a/src/workspacer.Native/Native/WindowsManager.cs
+++ b/src/workspacer.Native/Native/WindowsManager.cs
@@ -51,7 +51,6 @@ namespace workspacer
             Win32.SetWinEventHook(Win32.EVENT_CONSTANTS.EVENT_SYSTEM_MINIMIZESTART, Win32.EVENT_CONSTANTS.EVENT_SYSTEM_MINIMIZEEND, IntPtr.Zero, _hookDelegate, 0, 0, 0);
             Win32.SetWinEventHook(Win32.EVENT_CONSTANTS.EVENT_SYSTEM_MOVESIZESTART, Win32.EVENT_CONSTANTS.EVENT_SYSTEM_MOVESIZEEND, IntPtr.Zero, _hookDelegate, 0, 0, 0);
             Win32.SetWinEventHook(Win32.EVENT_CONSTANTS.EVENT_SYSTEM_FOREGROUND, Win32.EVENT_CONSTANTS.EVENT_SYSTEM_FOREGROUND, IntPtr.Zero, _hookDelegate, 0, 0, 0);
-            Win32.SetWinEventHook(Win32.EVENT_CONSTANTS.EVENT_OBJECT_NAMECHANGE, Win32.EVENT_CONSTANTS.EVENT_OBJECT_NAMECHANGE, IntPtr.Zero, _hookDelegate, 0, 0, 0);
             Win32.SetWinEventHook(Win32.EVENT_CONSTANTS.EVENT_OBJECT_LOCATIONCHANGE, Win32.EVENT_CONSTANTS.EVENT_OBJECT_LOCATIONCHANGE, IntPtr.Zero, _hookDelegate, 0, 0, 0);
 
             _mouseHook = MouseHook;
@@ -179,9 +178,6 @@ namespace workspacer
                         break;
                     case Win32.EVENT_CONSTANTS.EVENT_SYSTEM_FOREGROUND:
                         UpdateWindow(hwnd, WindowUpdateType.Foreground);
-                        break;
-                    case Win32.EVENT_CONSTANTS.EVENT_OBJECT_NAMECHANGE:
-                        UpdateWindow(hwnd, WindowUpdateType.TitleChange);
                         break;
                     case Win32.EVENT_CONSTANTS.EVENT_SYSTEM_MOVESIZESTART:
                         StartWindowMove(hwnd);

--- a/src/workspacer.Shared/Window/WindowUpdateType.cs
+++ b/src/workspacer.Shared/Window/WindowUpdateType.cs
@@ -13,7 +13,6 @@ namespace workspacer
         MinimizeStart,
         MinimizeEnd,
         Foreground,
-        TitleChange,
         MoveStart,
         MoveEnd,
         Move,


### PR DESCRIPTION
This PR removes the (so far) unused TITLE CHANGE event, which was causing flickering effects on several apps (editors):

- Notepad
- JetBrains products (in particular, the text editing window)
- Some Sun AWT based products

**Note:** this is not a complete fix for JetBrains issues (#61) or Sun AWT. However, it makes the IDE and other applications very usable, with the additional filter added in your configuration (in particular, for dropdowns, menus and other floating windows in Sun AWT):

```
    context.WindowRouter.AddFilter((window) => !window.Class.Contains("SunAwtWindow"));
```
