### PR TITLE
Add more default filters

### DIFF
--- a/src/workspacer/ConfigContext.cs
+++ b/src/workspacer/ConfigContext.cs
@@ -67,6 +67,9 @@ namespace workspacer
 
             // ignore watcher windows in workspacer
             WindowRouter.AddFilter((window) => window.ProcessId != _pipeServer.WatcherProcess.Id);
+
+            // ignore SunAwtWindows (common in some Sun AWT programs such at JetBrains products), prevents flickering
+            WindowRouter.AddFilter((window) => !window.Class.Contains("SunAwtWindow"));
         }
 
         public void ConnectToWatcher()


### PR DESCRIPTION
This PR adds an additional default filter for window classes containing `SunAwtWindow`.

This drastically reduces the flickering for all Sun AWT-based applications, such as JetBrains IDEs, especially when switching context menus or in autocomplete window scenarios. 

Issue #61 should be mostly mitigated, to the point it becomes comfortable to use with workspace, when used along with the previous related pull request (#178).