### PR TITLE
Prevents System.InvalidOperationException.

### DIFF
--- a/src/workspacer/PipeServer.cs
+++ b/src/workspacer/PipeServer.cs
@@ -25,6 +25,7 @@ namespace workspacer
             WatcherProcess.StartInfo.WorkingDirectory = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
             WatcherProcess.OutputDataReceived += (sender, args) => Console.WriteLine(args.Data);
             _semaphore = new SemaphoreSlim(1);
+            _semaphore.Wait();
         }
 
         public void Start()
@@ -32,6 +33,7 @@ namespace workspacer
             WatcherProcess.StartInfo.UseShellExecute = false;
             WatcherProcess.StartInfo.RedirectStandardInput = true;
             WatcherProcess.Start();
+            _semaphore.Release();
         }
 
         public void Dispose()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17995621/107837788-86c7ce80-6e07-11eb-9fbe-352d2181fd46.png)

This PR forces `PipeServer.Enqueue` to wait until `PipeServer.Start` is called. This prevents  `System.InvalidOperationException` from occurring.

(Note, this is a replacement for https://github.com/rickbutton/workspacer/pull/180)