### PR TITLE
Fixes wrong workspace for window after restarting.

### DIFF
--- a/src/workspacer.Shared/Workspace/StickyWorkspaceContainer.cs
+++ b/src/workspacer.Shared/Workspace/StickyWorkspaceContainer.cs
@@ -58,7 +58,7 @@ namespace workspacer
         {
             CreateWorkspace(_context.MonitorContainer.FocusedMonitor, name, layouts);
         }
-        
+
         public void CreateWorkspace(IMonitor monitor, string name, params ILayoutEngine[] layouts)
         {
             var newLayouts = layouts.Length > 0 ? _context.ProxyLayouts(layouts) : _context.DefaultLayouts();
@@ -124,7 +124,7 @@ namespace workspacer
 
         public IEnumerable<IWorkspace> GetAllWorkspaces()
         {
-            return _workspaces.SelectMany(kv => kv.Value);
+            return _orderedWorkspaces.SelectMany(kv => kv.Value);
         }
 
         public IMonitor GetCurrentMonitorForWorkspace(IWorkspace workspace)


### PR DESCRIPTION
## Reproduction:

Let there be 3 workspaces.
- Open Notepad on the 2nd workspace.
- Switch back to the first workspace.
- Restart workspacer.

## Expected behavior:

Notepad opens on the 2nd workspace.

## Actual behavior:

Notepad opens on the 3rd workspace.

## Diagnosis

This occurs because `StickyWorkspaceContainer._workspaces` is mutated in
`StickyWorkspaceContainer.AssignWorkspaceToMonitor`.

https://github.com/rickbutton/workspacer/blob/0aaff4437222e471ea0ffd282b948a9dfb8b7ff5/src/workspacer.Shared/Workspace/StickyWorkspaceContainer.cs#L112-L113