### PR TITLE
Move focused window to adjacent Workspace and switch to that Workspace

### DIFF
--- a/src/workspacer.Shared/Workspace/IWorkspaceContainer.cs
+++ b/src/workspacer.Shared/Workspace/IWorkspaceContainer.cs
@@ -16,6 +16,8 @@ namespace workspacer
 
         IWorkspace GetNextWorkspace(IWorkspace currentWorkspace);
         IWorkspace GetPreviousWorkspace(IWorkspace currentWorkspace);
+        int GetNextWorkspaceIndex(IWorkspace currentWorkspace);
+        int GetPreviousWorkspaceIndex(IWorkspace currentWorkspace);
 
         IWorkspace GetWorkspaceAtIndex(IWorkspace currentWorkspace, int index);
 

--- a/src/workspacer.Shared/Workspace/IWorkspaceContainer.cs
+++ b/src/workspacer.Shared/Workspace/IWorkspaceContainer.cs
@@ -20,6 +20,7 @@ namespace workspacer
         int GetPreviousWorkspaceIndex(IWorkspace currentWorkspace);
 
         IWorkspace GetWorkspaceAtIndex(IWorkspace currentWorkspace, int index);
+        int GetWorkspaceIndex(IWorkspace workspace);
 
         IWorkspace GetWorkspaceForMonitor(IMonitor monitor);
         IMonitor GetCurrentMonitorForWorkspace(IWorkspace workspace);

--- a/src/workspacer.Shared/Workspace/IWorkspaceManager.cs
+++ b/src/workspacer.Shared/Workspace/IWorkspaceManager.cs
@@ -29,6 +29,8 @@ namespace workspacer
         void SwitchFocusToPreviousMonitor();
         void SwitchFocusedMonitorToMouseLocation();
         void MoveFocusedWindowToWorkspace(int index);
+        void MoveFocusedWindowAndSwitchToNextWorkspace();
+        void MoveFocusedWindowAndSwitchToPreviousWorkspace();
         void MoveFocusedWindowToMonitor(int index);
         void MoveAllWindows(IWorkspace source, IWorkspace dest);
         void MoveFocusedWindowToNextMonitor();

--- a/src/workspacer.Shared/Workspace/StickyWorkspaceContainer.cs
+++ b/src/workspacer.Shared/Workspace/StickyWorkspaceContainer.cs
@@ -231,6 +231,16 @@ namespace workspacer
             }
         }
 
+        public int GetWorkspaceIndex(IWorkspace workspace)
+        {
+            VerifyExists(workspace);
+
+            var monitor = _wtm[workspace];
+            var workspaces = _orderedWorkspaces[monitor];
+
+            return workspaces.IndexOf(workspace);
+        }
+
         public IWorkspace GetWorkspaceByName(IWorkspace currentWorkspace, string name)
         {
             VerifyExists(currentWorkspace);

--- a/src/workspacer.Shared/Workspace/StickyWorkspaceContainer.cs
+++ b/src/workspacer.Shared/Workspace/StickyWorkspaceContainer.cs
@@ -182,11 +182,8 @@ namespace workspacer
         {
             VerifyExists(currentWorkspace);
 
-            var monitor = _wtm[currentWorkspace];
-            var workspaces = _orderedWorkspaces[monitor];
-
-            var index = workspaces.IndexOf(currentWorkspace);
-            if (index >= workspaces.Count - 1)
+            var index = GetWorkspaceIndex(currentWorkspace);
+            if (index >= _workspaces.Count - 1)
                 index = 0;
             else
                 index = index + 1;
@@ -198,10 +195,7 @@ namespace workspacer
         {
             VerifyExists(currentWorkspace);
 
-            var monitor = _wtm[currentWorkspace];
-            var workspaces = _orderedWorkspaces[monitor];
-
-            var index = workspaces.IndexOf(currentWorkspace);
+            var index = GetWorkspaceIndex(currentWorkspace);
             if (index == 0)
                 index = _workspaces.Count - 1;
             else

--- a/src/workspacer.Shared/Workspace/StickyWorkspaceContainer.cs
+++ b/src/workspacer.Shared/Workspace/StickyWorkspaceContainer.cs
@@ -178,6 +178,38 @@ namespace workspacer
             return workspaces[index];
         }
 
+        public int GetNextWorkspaceIndex(IWorkspace currentWorkspace)
+        {
+            VerifyExists(currentWorkspace);
+
+            var monitor = _wtm[currentWorkspace];
+            var workspaces = _orderedWorkspaces[monitor];
+
+            var index = workspaces.IndexOf(currentWorkspace);
+            if (index >= workspaces.Count - 1)
+                index = 0;
+            else
+                index = index + 1;
+
+            return index;
+        }
+
+        public int GetPreviousWorkspaceIndex(IWorkspace currentWorkspace)
+        {
+            VerifyExists(currentWorkspace);
+
+            var monitor = _wtm[currentWorkspace];
+            var workspaces = _orderedWorkspaces[monitor];
+
+            var index = workspaces.IndexOf(currentWorkspace);
+            if (index == 0)
+                index = _workspaces.Count - 1;
+            else
+                index = index - 1;
+
+            return index;
+        }
+
         public IWorkspace GetWorkspaceAtIndex(IWorkspace currentWorkspace, int index)
         {
             VerifyExists(currentWorkspace);

--- a/src/workspacer.Shared/Workspace/WorkspaceContainer.cs
+++ b/src/workspacer.Shared/Workspace/WorkspaceContainer.cs
@@ -143,6 +143,13 @@ namespace workspacer
             return _workspaces[index];
         }
 
+        public int GetWorkspaceIndex(IWorkspace workspace)
+        {
+            VerifyExists(workspace);
+
+            return _workspaceMap[workspace];
+        }
+
         public IMonitor GetCurrentMonitorForWorkspace(IWorkspace workspace)
         {
             return _mtw.Keys.FirstOrDefault(m => _mtw[m] == workspace);

--- a/src/workspacer.Shared/Workspace/WorkspaceContainer.cs
+++ b/src/workspacer.Shared/Workspace/WorkspaceContainer.cs
@@ -109,6 +109,30 @@ namespace workspacer
 
             return _workspaces[index];
         }
+        public int GetNextWorkspaceIndex(IWorkspace currentWorkspace)
+        {
+            VerifyExists(currentWorkspace);
+            var index = _workspaceMap[currentWorkspace];
+            if (index >= _workspaces.Count - 1)
+                index = 0;
+            else
+                index = index + 1;
+
+            return index;
+        }
+
+        public int GetPreviousWorkspaceIndex(IWorkspace currentWorkspace)
+        {
+            VerifyExists(currentWorkspace);
+            var index = _workspaceMap[currentWorkspace];
+            if (index == 0)
+                index = _workspaces.Count - 1;
+            else
+                index = index - 1;
+
+            return index;
+        }
+
 
         public IWorkspace GetWorkspaceAtIndex(IWorkspace currentWorkspace, int index)
         {

--- a/src/workspacer.Shared/Workspace/WorkspaceContainer.cs
+++ b/src/workspacer.Shared/Workspace/WorkspaceContainer.cs
@@ -112,7 +112,7 @@ namespace workspacer
         public int GetNextWorkspaceIndex(IWorkspace currentWorkspace)
         {
             VerifyExists(currentWorkspace);
-            var index = _workspaceMap[currentWorkspace];
+            var index = GetWorkspaceIndex(currentWorkspace);
             if (index >= _workspaces.Count - 1)
                 index = 0;
             else
@@ -124,7 +124,7 @@ namespace workspacer
         public int GetPreviousWorkspaceIndex(IWorkspace currentWorkspace)
         {
             VerifyExists(currentWorkspace);
-            var index = _workspaceMap[currentWorkspace];
+            var index = GetWorkspaceIndex(currentWorkspace);
             if (index == 0)
                 index = _workspaces.Count - 1;
             else

--- a/src/workspacer/Config/workspacer.config.template.csx
+++ b/src/workspacer/Config/workspacer.config.template.csx
@@ -18,6 +18,6 @@ Action<IConfigContext> doConfig = (context) =>
     context.AddFocusIndicator();
     var actionMenu = context.AddActionMenu();
 
-    context.WorkspaceContainer.CreateWorkspaces("one", "two", "three", "four", "five");
+    context.WorkspaceContainer.CreateWorkspaces("1", "2", "3", "4", "5");
 };
 return doConfig;

--- a/src/workspacer/Keybinds/KeybindManager.cs
+++ b/src/workspacer/Keybinds/KeybindManager.cs
@@ -310,6 +310,12 @@ You can either change your custom hotkey or reassign the default hotkey";
             Subscribe(mod, Keys.Right,
                 () => _context.Workspaces.SwitchToNextWorkspace(), "switch to next workspace");
 
+            Subscribe(mod | KeyModifiers.LShift, Keys.Left,
+                () => _context.Workspaces.MoveFocusedWindowAndSwitchToPreviousWorkspace(), "move window to previous workspace and switch to it");
+
+            Subscribe(mod | KeyModifiers.LShift, Keys.Right,
+                () => _context.Workspaces.MoveFocusedWindowAndSwitchToNextWorkspace(), "move window to next workspace and switch to it");
+
             Subscribe(mod, Keys.Oemtilde,
                 () => _context.Workspaces.SwitchToLastFocusedWorkspace(), "switch to last focused workspace");
 

--- a/src/workspacer/Keybinds/KeybindManager.cs
+++ b/src/workspacer/Keybinds/KeybindManager.cs
@@ -310,10 +310,10 @@ You can either change your custom hotkey or reassign the default hotkey";
             Subscribe(mod, Keys.Right,
                 () => _context.Workspaces.SwitchToNextWorkspace(), "switch to next workspace");
 
-            Subscribe(mod | KeyModifiers.LShift, Keys.Left,
+            Subscribe(mod | KeyModifiers.Control, Keys.Left,
                 () => _context.Workspaces.MoveFocusedWindowAndSwitchToPreviousWorkspace(), "move window to previous workspace and switch to it");
 
-            Subscribe(mod | KeyModifiers.LShift, Keys.Right,
+            Subscribe(mod | KeyModifiers.Control, Keys.Right,
                 () => _context.Workspaces.MoveFocusedWindowAndSwitchToNextWorkspace(), "move window to next workspace and switch to it");
 
             Subscribe(mod, Keys.Oemtilde,

--- a/src/workspacer/Workspace/WorkspaceManager.cs
+++ b/src/workspacer/Workspace/WorkspaceManager.cs
@@ -231,6 +231,21 @@ namespace workspacer
                 nextWindow?.Focus();
             }
         }
+        public void MoveFocusedWindowAndSwitchToNextWorkspace()
+        {
+            Logger.Debug("MoveFocusedWindowAndSwitchToNextWorkspace()");
+            var targetWorkspaceIndex = _context.WorkspaceContainer.GetNextWorkspaceIndex(FocusedWorkspace);
+            _context.Workspaces.MoveFocusedWindowToWorkspace(targetWorkspaceIndex);
+            _context.Workspaces.SwitchToNextWorkspace();
+        }
+
+        public void MoveFocusedWindowAndSwitchToPreviousWorkspace()
+        {
+            Logger.Debug("MoveFocusedWindowAndSwitchToPreviousWorkspace()");
+            var targetWorkspaceIndex = _context.WorkspaceContainer.GetPreviousWorkspaceIndex(FocusedWorkspace);
+            _context.Workspaces.MoveFocusedWindowToWorkspace(targetWorkspaceIndex);
+            _context.Workspaces.SwitchToPreviousWorkspace();
+        }
 
         public void MoveFocusedWindowToMonitor(int index)
         {


### PR DESCRIPTION
Hi, first time making a pull request, so please do point out if this PR is not up to standard.

What I'm proposing here is adding functionality to move the focused window to an adjacent workspace and "follow it" in the sense that you switch to the workspace where the focused window now resides. 

As such, it is just a "shorthand" for placing a window in the `n`'th workspace with `Alt+Shift+{n}` and then switching to it with `Alt+{n}`.

I added the following key bindings for the above mentioned, for which I could not find any conflicts and I believe are quite intuitive as an extension of the original ones:
- `Alt+Shift+Left`    Move Focused Window To Previous Workspace And Switch to It
- `Alt+Shift+Right`  Move Focused Window To Next Workspace And Switch to It