### PR TITLE
ShowKeybindDialog now renders a table.

### DIFF
--- a/src/workspacer.Shared/KeyValueTable.Designer.cs
+++ b/src/workspacer.Shared/KeyValueTable.Designer.cs
@@ -40,6 +40,9 @@ namespace workspacer
             this.DataGridView.AllowUserToAddRows = false;
             this.DataGridView.AllowUserToDeleteRows = false;
             this.DataGridView.AllowUserToOrderColumns = true;
+            this.DataGridView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.DataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.DataGridView.Location = new System.Drawing.Point(18, 83);
             this.DataGridView.Name = "DataGridView";
@@ -60,6 +63,9 @@ namespace workspacer
             // 
             // SearchBox
             // 
+            this.SearchBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.SearchBox.Location = new System.Drawing.Point(18, 54);
             this.SearchBox.Name = "SearchBox";
             this.SearchBox.PlaceholderText = "Search";
@@ -71,10 +77,12 @@ namespace workspacer
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScroll = true;
             this.ClientSize = new System.Drawing.Size(915, 532);
             this.Controls.Add(this.SearchBox);
             this.Controls.Add(this.SubtitleText);
             this.Controls.Add(this.DataGridView);
+            this.MinimumSize = new System.Drawing.Size(300, 250);
             this.Name = "KeyValueTable";
             this.Text = "KeyValueTable";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.KeyValueTable_FormClosing);

--- a/src/workspacer.Shared/KeyValueTable.Designer.cs
+++ b/src/workspacer.Shared/KeyValueTable.Designer.cs
@@ -1,0 +1,92 @@
+﻿
+namespace workspacer
+{
+    partial class KeyValueTable
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.DataGridView = new System.Windows.Forms.DataGridView();
+            this.SubtitleText = new System.Windows.Forms.Label();
+            this.SearchBox = new System.Windows.Forms.TextBox();
+            ((System.ComponentModel.ISupportInitialize)(this.DataGridView)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // DataGridView
+            // 
+            this.DataGridView.AllowUserToAddRows = false;
+            this.DataGridView.AllowUserToDeleteRows = false;
+            this.DataGridView.AllowUserToOrderColumns = true;
+            this.DataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.DataGridView.Location = new System.Drawing.Point(18, 83);
+            this.DataGridView.Name = "DataGridView";
+            this.DataGridView.ReadOnly = true;
+            this.DataGridView.RowTemplate.Height = 25;
+            this.DataGridView.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.DataGridView.Size = new System.Drawing.Size(882, 442);
+            this.DataGridView.TabIndex = 0;
+            // 
+            // SubtitleText
+            // 
+            this.SubtitleText.AutoSize = true;
+            this.SubtitleText.Location = new System.Drawing.Point(14, 10);
+            this.SubtitleText.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.SubtitleText.Name = "SubtitleText";
+            this.SubtitleText.Size = new System.Drawing.Size(0, 15);
+            this.SubtitleText.TabIndex = 2;
+            // 
+            // SearchBox
+            // 
+            this.SearchBox.Location = new System.Drawing.Point(18, 54);
+            this.SearchBox.Name = "SearchBox";
+            this.SearchBox.PlaceholderText = "Search";
+            this.SearchBox.Size = new System.Drawing.Size(882, 23);
+            this.SearchBox.TabIndex = 3;
+            this.SearchBox.TextChanged += new System.EventHandler(this.SearchBox_TextChanged);
+            // 
+            // KeyValueTable
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(915, 532);
+            this.Controls.Add(this.SearchBox);
+            this.Controls.Add(this.SubtitleText);
+            this.Controls.Add(this.DataGridView);
+            this.Name = "KeyValueTable";
+            this.Text = "KeyValueTable";
+            ((System.ComponentModel.ISupportInitialize)(this.DataGridView)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.DataGridView DataGridView;
+        private System.Windows.Forms.Label SubtitleText;
+        private System.Windows.Forms.TextBox SearchBox;
+    }
+}

--- a/src/workspacer.Shared/KeyValueTable.Designer.cs
+++ b/src/workspacer.Shared/KeyValueTable.Designer.cs
@@ -77,6 +77,7 @@ namespace workspacer
             this.Controls.Add(this.DataGridView);
             this.Name = "KeyValueTable";
             this.Text = "KeyValueTable";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.KeyValueTable_FormClosing);
             ((System.ComponentModel.ISupportInitialize)(this.DataGridView)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/src/workspacer.Shared/KeyValueTable.cs
+++ b/src/workspacer.Shared/KeyValueTable.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace workspacer
+{
+    public partial class KeyValueTable : Form
+    {
+        private readonly List<Tuple<string, string>> Items;
+        private readonly BindingSource Source;
+
+        public KeyValueTable(string title, string subtitle, string header1, string header2, List<Tuple<string, string>> items)
+        {
+            InitializeComponent();
+
+            Text = title;
+            SubtitleText.Text = subtitle;
+            Items = items;
+
+            Source = new BindingSource() { DataSource = Items };
+
+            DataGridView.DataSource = Source;
+            DataGridView.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
+
+            var firstCol = DataGridView.Columns[0];
+            firstCol.HeaderText = header1;
+            firstCol.DataPropertyName = "Item1";
+
+            var secondCol = DataGridView.Columns[1];
+            secondCol.HeaderText = header2;
+            secondCol.DataPropertyName = "Item2";
+
+            SearchBox.Focus();
+        }
+
+        private void SearchBox_TextChanged(object sender, EventArgs e)
+        {
+            var searchText = SearchBox.Text.ToLower();
+
+            Source.DataSource = Items.Where(i => i.Item1.ToLower().Contains(searchText) || i.Item2.ToLower().Contains(searchText));
+            Source.ResetBindings(false);
+        }
+    }
+}

--- a/src/workspacer.Shared/KeyValueTable.cs
+++ b/src/workspacer.Shared/KeyValueTable.cs
@@ -46,5 +46,11 @@ namespace workspacer
             Source.DataSource = Items.Where(i => i.Item1.ToLower().Contains(searchText) || i.Item2.ToLower().Contains(searchText));
             Source.ResetBindings(false);
         }
+
+        private void KeyValueTable_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            Hide();
+            e.Cancel = true;
+        }
     }
 }

--- a/src/workspacer.Shared/KeyValueTable.resx
+++ b/src/workspacer.Shared/KeyValueTable.resx
@@ -1,0 +1,60 @@
+﻿<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/workspacer.Shared/StringExtensions.cs
+++ b/src/workspacer.Shared/StringExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace workspacer
+{
+    public static class StringExtensions
+    {
+        public static string Capitalize(this string input) =>
+            input switch
+            {
+                null => throw new ArgumentNullException(nameof(input)),
+                "" => "",
+                _ => input.First().ToString().ToUpper() + input[1..]
+            };
+    }
+}

--- a/src/workspacer/Keybinds/KeybindManager.cs
+++ b/src/workspacer/Keybinds/KeybindManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
@@ -34,7 +34,7 @@ namespace workspacer
         private IDictionary<Sub, NamedBind<KeybindHandler>> _kbdSubs;
         private IDictionary<MouseEvent, NamedBind<MouseHandler>> _mouseSubs;
 
-        private TextBlockMessage _keybindDialog;
+        private KeyValueTable _keybindTable;
         private TextBlockMessage _keybindWarning;
 
         public KeybindManager(IConfigContext context)
@@ -375,44 +375,53 @@ You can either change your custom hotkey or reassign the default hotkey";
         {
             var parts = new List<string>();
 
+            if (mods.HasFlag(KeyModifiers.Win))
+                parts.Add("Win");
             if (mods.HasFlag(KeyModifiers.LAlt))
-                parts.Add("alt");
+                parts.Add("Alt");
             if (mods.HasFlag(KeyModifiers.LShift))
-                parts.Add("shift");
+                parts.Add("Shift");
 
             if (keys == Keys.Oemcomma) { parts.Add(","); }
             else if (keys == Keys.OemPeriod) { parts.Add("."); }
             else if (keys == Keys.Oem2) { parts.Add("/"); }
-            else if (new Regex("d\\d").IsMatch(keys.ToString().ToLower()))
+            else if (new Regex("d\\d").IsMatch(keys.ToString().Capitalize()))
             {
-                parts.Add(keys.ToString().ToLower()[1].ToString());
+                parts.Add(keys.ToString().Capitalize()[1].ToString());
             }
             else
             {
-                parts.Add(keys.ToString().ToLower());
+                parts.Add(keys.ToString().Capitalize());
             }
 
-            return string.Join("-", parts);
+            return string.Join(" + ", parts);
         }
 
         public void ShowKeybindDialog()
         {
-            if (_keybindDialog == null)
+            if (_keybindTable == null)
             {
-                var message = string.Join("\r\n", this.Keybinds.Select(k => (k.Item3 ?? "<unnamed>") + "  -  " + GetKeybindString(k.Item1, k.Item2)));
-                _keybindDialog = new TextBlockMessage("workspacer keybinds", "below is the list of the current keybindings", message, new List<Tuple<string, Action>>()
-                
-                {
-                    new Tuple<string, Action>("ok", () => { }),
-                });
-            } 
+                _keybindTable = new KeyValueTable(
+                    "workspacer keybinds",
+                    "Below is the list of the current keybindings",
+                    "Description",
+                    "Keybind",
+                    Keybinds.Select(k => new Tuple<string, string>(
+                            k.Item3 ?? "<unnamed>",
+                            GetKeybindString(k.Item1, k.Item2)
+                        )
+                    ).ToList()
+                );
 
-            if (_keybindDialog.Visible)
+            }
+
+            if (_keybindTable.Visible)
             {
-                _keybindDialog.Hide();
-            } else
+                _keybindTable.Hide();
+            }
+            else
             {
-                _keybindDialog.Show();
+                _keybindTable.Show();
             }
         }
     }

--- a/src/workspacer/Keybinds/KeybindManager.cs
+++ b/src/workspacer/Keybinds/KeybindManager.cs
@@ -385,7 +385,7 @@ You can either change your custom hotkey or reassign the default hotkey";
             if (keys == Keys.Oemcomma) { parts.Add(","); }
             else if (keys == Keys.OemPeriod) { parts.Add("."); }
             else if (keys == Keys.Oem2) { parts.Add("/"); }
-            else if (new Regex("d\\d").IsMatch(keys.ToString().Capitalize()))
+            else if (new Regex("\\d").IsMatch(keys.ToString().Capitalize()))
             {
                 parts.Add(keys.ToString().Capitalize()[1].ToString());
             }


### PR DESCRIPTION
This adds `KeyValueTable`, which is used to replace `TextBlockMessage` for displaying the current keybindings.

**Changes:**

- Added `KeyValueTable`
- Added `Capitalize` string extension method
- `GetKeybindString` capitalizes keys to aid readability
- `GetKeybindString` adds support for `KeyModifiers.Win`

![image](https://user-images.githubusercontent.com/17995621/108593055-41db0380-73d6-11eb-82b0-bc6f30a73bd4.png)
