### PR TITLE
Ignores Snip & Sketch.

### DIFF
--- a/src/workspacer.Shared/Workspace/WindowRouter.cs
+++ b/src/workspacer.Shared/Workspace/WindowRouter.cs
@@ -31,6 +31,7 @@ namespace workspacer
             IgnoreWindowClass("Progman");
             IgnoreProcessName("StartMenuExperienceHost");
             IgnoreProcessName("SearchApp");
+            IgnoreProcessName("ScreenClippingHost");
             _filters.Add((window) => !(window.ProcessId == Process.GetCurrentProcess().Id));
         }
 

--- a/src/workspacer/ConfigContext.cs
+++ b/src/workspacer/ConfigContext.cs
@@ -70,6 +70,9 @@ namespace workspacer
 
             // ignore SunAwtWindows (common in some Sun AWT programs such at JetBrains products), prevents flickering
             WindowRouter.AddFilter((window) => !window.Class.Contains("SunAwtWindow"));
+
+            // ignore Snip & Sketch
+            WindowRouter.AddFilter((window) => !window.ProcessFileName.Equals("ScreenClippingHost.exe"));
         }
 
         public void ConnectToWatcher()

--- a/src/workspacer/ConfigContext.cs
+++ b/src/workspacer/ConfigContext.cs
@@ -70,9 +70,6 @@ namespace workspacer
 
             // ignore SunAwtWindows (common in some Sun AWT programs such at JetBrains products), prevents flickering
             WindowRouter.AddFilter((window) => !window.Class.Contains("SunAwtWindow"));
-
-            // ignore Snip & Sketch
-            WindowRouter.AddFilter((window) => !window.ProcessFileName.Equals("ScreenClippingHost.exe"));
         }
 
         public void ConnectToWatcher()


### PR DESCRIPTION
This means that Snip & Sketch can be used as normal, instead of being treated as a separate window.

This can be tested by calling Snip & Sketch using the shortcut `Win` + `Shift` + `S`